### PR TITLE
Fix Killing Tally perk

### DIFF
--- a/isro.js
+++ b/isro.js
@@ -239,7 +239,7 @@ const permuter = {
     "Keep Away": 3619207468,
     Kickstart: 1754714824,
     "Kill Clip": 1015611457,
-    "Killing Tally": 2782457288,
+    "Killing Tally": 557221067,
     "Killing Wind": 2450788523,
     "Kinetic Tremors": 3891536761,
     "King Dot K2": 1452368633,


### PR DESCRIPTION
Killing Tally has two versions, the original on 21% Delirium, and everything else since it came back. This updates it from the 21% version to the one that is actually found on weapons these days.

https://www.light.gg/db/items/2782457288/killing-tally/
https://www.light.gg/db/items/557221067/killing-tally/
