### PR TITLE
Fix hash for Offhand Strike

### DIFF
--- a/isro.js
+++ b/isro.js
@@ -274,7 +274,7 @@ const permuter = {
     "Natural String": 1784898267,
     "No Distractions": 2866798147,
     "Noble Deeds": 1823011807,
-    "Offhand Strike": 416023159,
+    "Offhand Strike": 2416023159,
     "Omolon Fluid Dynamics": 2839173408,
     "One For All": 4049631843,
     "One Quiet Moment": 4091460919,


### PR DESCRIPTION
Looks like Offhand Strike is missing the initial '2' from its hash.
https://data.destinysets.com/i/InventoryItem:2416023159